### PR TITLE
Fixed STDIN.nextLine-related bugs and added JRE Library

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-12">
-		<attributes>
-			<attribute name="module" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/src/unl/cse/library/LibraryDemo.java
+++ b/src/unl/cse/library/LibraryDemo.java
@@ -53,6 +53,8 @@ public class LibraryDemo {
         System.out.print("Enter your search term: ");
         String query = STDIN.next();
         
+        STDIN.nextLine(); // to account for search terms with more than one word
+        
         switch (userChoice) {
         	case 1:
         		printBooks(this.lib.titleSearch(query));
@@ -90,6 +92,7 @@ public class LibraryDemo {
         //change this function
         System.out.println("Please enter the details of the book you want to add to the library");
         System.out.println("Enter the title of the book: ");
+        STDIN.nextLine();
         String title = STDIN.nextLine();
         System.out.println("Enter the first name of the author: ");
         String firstName = STDIN.nextLine();


### PR DESCRIPTION
Things I fixed:
* When a student would download this lab, the JRE Library would not be included, so I reconfigured the build path.
* The "Enter book title" and "Enter author's first name" lines would both print out at once when the user tried to enter a book into the library, so the arguments for the constructor would be wrong.
* The search method would throw an error if the search term was more than one word long

I wanted to edit the handout too, but I figured it might be easier if you do it since it's in LaTeX and you probably have all the right extensions installed already. I just wanted to add this constructor tutorial (https://docs.oracle.com/javase/tutorial/java/javaOO/constructors.html) to Step 3 of the "Prior To Lab" section in the handout. It also might make sense to put the constructor tutorials before the object creation tutorial in the handout since the latter references concepts from the former.